### PR TITLE
Rename `OpenAIChatGPTAdapter`

### DIFF
--- a/aishell/adapters/__init__.py
+++ b/aishell/adapters/__init__.py
@@ -1,1 +1,1 @@
-from .openai_chatgpt_adapter import OpenAIChatGPTAdapter as OpenAIChatGPTAdapter
+from .openai_cookie_adapter import OpenAICookieAdapter as OpenAICookieAdapter

--- a/aishell/adapters/openai_cookie_adapter.py
+++ b/aishell/adapters/openai_cookie_adapter.py
@@ -5,10 +5,10 @@ from yt_dlp.cookies import SUPPORTED_BROWSERS, extract_cookies_from_browser
 from yt_dlp.utils import YoutubeDLCookieJar
 
 
-class OpenAIChatGPTAdapter:
+class OpenAICookieAdapter:
 
     def __init__(self, browser_name: str):
-        if browser_name not in SUPPORTED_BROWSERS:  # type: ignore
+        if browser_name not in SUPPORTED_BROWSERS:
             raise ValueError(f'Browser {browser_name} is not supported. Supported browsers are: {SUPPORTED_BROWSERS}')
         self.BROWSER_NAME = browser_name
 

--- a/aishell/adapters/test/test_openai_chatgpt_adapter.py
+++ b/aishell/adapters/test/test_openai_chatgpt_adapter.py
@@ -1,7 +1,7 @@
 import pytest
 from yt_dlp.cookies import SUPPORTED_BROWSERS
 
-from aishell.adapters import OpenAIChatGPTAdapter
+from aishell.adapters import OpenAICookieAdapter
 
 
 class TestChatGPTAccessTokenAdapterInit:
@@ -9,9 +9,9 @@ class TestChatGPTAccessTokenAdapterInit:
     def test_fail_when_invalid_browser_name_is_given(self) -> None:
         '''잘못된 브라우저 이름을 입력했을 때 ValueError가 발생한다.'''
         with pytest.raises(ValueError):
-            OpenAIChatGPTAdapter('invalid_browser_name')
+            OpenAICookieAdapter('invalid_browser_name')
 
     @pytest.mark.parametrize('browser_name', SUPPORTED_BROWSERS)
     def test_success_when_valid_browser_name_is_given(self, browser_name: str) -> None:
         '''올바른 브라우저 이름을 입력했을 때 ValueError가 발생하지 않는다'''
-        OpenAIChatGPTAdapter(browser_name)
+        OpenAICookieAdapter(browser_name)

--- a/aishell/cli.py
+++ b/aishell/cli.py
@@ -5,7 +5,7 @@ import typer
 from rich.console import Console
 from yt_dlp.cookies import SUPPORTED_BROWSERS
 
-from aishell.adapters.openai_chatgpt_adapter import OpenAIChatGPTAdapter
+from aishell.adapters.openai_cookie_adapter import OpenAICookieAdapter
 from aishell.exceptions import UnauthorizedAccessError
 from aishell.models.language_model import LanguageModel
 from aishell.query_clients import GPT3Client, OfficialChatGPTClient, QueryClient, ReverseEngineeredChatGPTClient
@@ -32,7 +32,7 @@ def ask(question: str, language_model: LanguageModel = LanguageModel.REVERSE_ENG
             print('You are not logged in to OpenAI, attempting to log you in...')
             _open_chatgpt_browser()
             BROWSER_NAME = typer.prompt(f'Which browser did you use to log in? [{SUPPORTED_BROWSERS}]')
-            adapter = OpenAIChatGPTAdapter(BROWSER_NAME)
+            adapter = OpenAICookieAdapter(BROWSER_NAME)
             session_token = adapter.get_openai_session_token()
             query_client = ReverseEngineeredChatGPTClient(session_token=session_token)
 


### PR DESCRIPTION
This commit renames `OpenAIChatGPTAdapter` to `OpenAICookieAdapter`,
to reflect the purpose of class more clear.

## Context
-

## Changes
-
