### PR TITLE
Bump up python version to `3.9`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ reportMissingTypeStubs = false    # Ignore errors from modules without type stub
 reportUnknownMemberType = false   # Ignore errors from untyped function calls in third-party modules
 reportUnknownVariableType = false # Ignore errors from untyped function calls in third-party modules
 
+pythonVersion = "3.9"
 
 [tool.yapf]
 based_on_style = "pep8"
@@ -38,7 +39,7 @@ line-length = 119
 select = ["PLE", "PLR", "PLW", "E", "W", "F", "I", "Q", "C", "B"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 poetry = "^1.3.1"
 revchatgpt = "^3.0.5"
 typer = { extras = ["all"], version = "^0.7.0" }


### PR DESCRIPTION
## Context
- Current project's minimum python version is 3.8, while we are using some 3.9 syntax in our project.
	- Such as `list` as type hint

## Changes
- Bump up baby
